### PR TITLE
Show warnings when signatures are not validated

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -89,7 +89,7 @@ commits as properly signed.
 npm run collaborator:sync-keys
 ```
 
-Once you have synced the keys to your localk keyring, you can now
+Once you have synced the keys to your local keyring, you can now
 test that all commits are indeed signed.
 
 ```shell


### PR DESCRIPTION
Related to #1
 
`git` shows warnings when a key is not certified with a trusted signature. In order to archive that, I added a new flag `--trust-commits`. If the flag is enabled and not certified key is found, the program will exit. By default, the program only shows warnings without existing.